### PR TITLE
Insert many

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,13 @@
+*   Add `insert_many` method to `ActiveRecord::Persistence`, allowing bulk
+    inserts akin to the bulk updates provided by `update_all` and bulk deletes
+    by `delete_all`.
+
+    Supports skipping or upserting duplicates through the `ON CONFLICT` syntax
+    for Postgres (9.5+) and Sqlite (3.24+) and `INSERT IGNORE`/
+    `ON DUPLICATE KEY UPDATE` syntax for MySQL.
+
+    *Bob Lail*
+
 *   Make `t.timestamps` with precision by default.
 
     *Ryuta Kamizono*

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -389,6 +389,14 @@ module ActiveRecord
         false
       end
 
+      def supports_insert_returning?
+        false
+      end
+
+      def supports_insert_on_conflict?
+        false
+      end
+
       # This is meant to be implemented by the adapters that support extensions
       def disable_extension(name)
       end

--- a/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -62,6 +62,10 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_on_conflict?
+        true
+      end
+
       # HELPER METHODS ===========================================
 
       def each_hash(result) # :nodoc:

--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -196,6 +196,14 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_returning?
+        true
+      end
+
+      def supports_insert_on_conflict?
+        postgresql_version >= 90500
+      end
+
       def index_algorithms
         { concurrently: "CONCURRENTLY" }
       end

--- a/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb
@@ -137,6 +137,10 @@ module ActiveRecord
         true
       end
 
+      def supports_insert_on_conflict?
+        sqlite_version >= "3.24.0"
+      end
+
       def active?
         @active
       end

--- a/activerecord/test/cases/helper.rb
+++ b/activerecord/test/cases/helper.rb
@@ -61,6 +61,18 @@ def supports_savepoints?
   ActiveRecord::Base.connection.supports_savepoints?
 end
 
+def supports_partial_index?
+  ActiveRecord::Base.connection.supports_partial_index?
+end
+
+def supports_insert_returning?
+  ActiveRecord::Base.connection.supports_insert_returning?
+end
+
+def supports_insert_on_conflict?
+  ActiveRecord::Base.connection.supports_insert_on_conflict?
+end
+
 def with_env_tz(new_tz = "US/Eastern")
   old_tz, ENV["TZ"] = ENV["TZ"], new_tz
   yield

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -106,6 +106,10 @@ ActiveRecord::Schema.define do
     t.column :font_size, :integer, default: 0
     t.column :difficulty, :integer, default: 0
     t.column :cover, :string, default: "hard"
+    t.string :isbn
+    t.datetime :published_on
+    t.index [:author_id, :name], unique: true
+    t.index :isbn, where: "published_on IS NOT NULL", unique: true
   end
 
   create_table :booleans, force: true do |t|


### PR DESCRIPTION
Inserts a record (or multiple records) into the database. This method constructs a single SQL INSERT statement and sends it straight to the database. It does not instantiate the involved models and it does not trigger Active Record callbacks or validations. However, values passed to `insert_many` will still go through Active Record's normal type casting and serialization.

The `attributes` parameter can be either a Hash or an Array of Hashes. These Hashes describe the attributes on the objects that are to be created.

##### Options

- `[:returning]`
   (Postgres-only) An array of column names that should be returned for all successfully inserted rows. By default, the primary key(s) will be returned for every inserted rows. Can be set to `false` to return nothing.

- `[:on_conflict]`
    A hash that describes how the database should respond to duplicate rows:
    `{ do: :nothing }` — skip duplicate rows
    `{ do: :update }` — update duplicate rows (perform an UPSERT)

    For databases that support it, the hash can also specify which of several unique indexes to handle conficts for:
    `{ column: %w{ isbn }, do: :update }`

    For databases that support partial indexes, the hash can also identify the unique index with its conditional
    `{ column: %w{ isbn }, where: "published_on IS NOT NULL", do: :update }`

###### Examples

```ruby
# Insert a single record
Book.insert_many title: 'Agile Web Development with Rails', author: 'David'

# Insert multiple records
Book.insert_many [
  { title: 'Agile Web Development with Rails', author: 'David' },
  { title: 'Eloquent Ruby', author: 'Russ Olsen' }
]

# Insert multiple records and skip duplicates
Book.insert_many [
  { id: 1, title: 'Agile Web Development with Rails', author: 'David' },
  { id: 2, title: 'Eloquent Ruby', author: 'Russ Olsen' }
],
  on_conflict: { do: :nothing }
```